### PR TITLE
Add UI elements and bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cp kubectl-crossplane /usr/local/bin
 #### Install the Platform Configuration
 
 ```console
-PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-cloud-native:v0.0.1
+PLATFORM_CONFIG=registry.upbound.io/upbound/platform-ref-cloud-native:v0.0.2
 
 kubectl crossplane install configuration ${PLATFORM_CONFIG}
 kubectl get pkg
@@ -123,7 +123,7 @@ Set these to match your settings:
 UPBOUND_ORG=acme
 UPBOUND_ACCOUNT_EMAIL=me@acme.io
 REPO=platform-ref-cloud-native
-VERSION_TAG=v0.0.1
+VERSION_TAG=v0.0.2
 REGISTRY=registry.upbound.io
 PLATFORM_CONFIG=${REGISTRY:+$REGISTRY/}${UPBOUND_ORG}/${REPO}:${VERSION_TAG}
 ```

--- a/cluster/definition.yaml
+++ b/cluster/definition.yaml
@@ -48,7 +48,7 @@ metadata:
           controlType: singleSelect
           path: ".spec.nodes.size"
           title: Node Size
-          description: Desired node count, from 1 to 100.
+          description: The size of each node and it's general resource usage
           default: small
           enum:
           - small
@@ -65,10 +65,61 @@ metadata:
           type: string
           path: ".spec.services.operators.prometheus.version"
           title: Prometheus Chart Version
-          description: The version of kube-prometheus-stack chart to install
-          default: 10.1.0
+          description: The version of Prometheus chart to install
+          default: 14.5.0
           validation:
           - required: false
+        - name: jaegerVersion
+          controlType: singleInput
+          type: string
+          path: ".spec.services.operators.jaeger.version"
+          title: Jaeger Chart Version
+          description: The version of Jaeger chart to install
+          default: 0.45.0
+          validation:
+          - required: false
+        - name: fluentdVersion
+          controlType: singleInput
+          type: string
+          path: ".spec.services.operators.fluentd.version"
+          title: Fluentd Chart Version
+          description: The version of Fluentd chart to install
+          default: 3.6.4
+          validation:
+          - required: false
+        - name: rookVersion
+          controlType: singleInput
+          type: string
+          path: ".spec.services.operators.rook.version"
+          title: Rook Chart Version
+          description: The version of Rook chart to install
+          default: v1.5.9
+          validation:
+          - required: false
+        - name: fluxVersion
+          controlType: singleInput
+          type: string
+          path: ".spec.services.operators.flux.version"
+          title: Flux Chart Version
+          description: The version of Flux chart to install
+          default: 1.8.0
+          validation:
+          - required: false
+        - name: fluxUrl
+          controlType: singleInput
+          type: string
+          path: ".spec.services.operators.flux.url"
+          title: Application Git Repository URL
+          description: The URL for the Git repository containing the application to sync to the cluster
+          default: git@github.com:fluxcd/flux-get-started
+          validation:
+          - required: true
+        - name: fluxReadonly
+          controlType: checkboxSingle
+          path: ".spec.services.operators.flux.readonly"
+          title: Read-only Repository
+          description: If true, Flux will treat the application repository as read-only
+          default: true
 spec:
   claimNames:
     kind: ClusterClaim

--- a/cluster/gcp/composition.yaml
+++ b/cluster/gcp/composition.yaml
@@ -43,7 +43,7 @@ spec:
         kind: GKECluster
         spec:
           forProvider:
-            initialClusterVersion: "1.16"
+            initialClusterVersion: "1.18"
             location: us-west2
             masterAuth:
               # setting this master auth user name enables basic auth so that a client (e.g.,


### PR DESCRIPTION
This PR does the following:

* Adds UI elements to the cluster resources so users can create and configure a cluster through a UI experience
* Bumps the version of GKE to 1.18 because 1.16 is no longer supported in GCP
* Bumps the README version to v0.0.2, the next release